### PR TITLE
Fix rpi0w issue after resize

### DIFF
--- a/board/raspberrypi/rpi/rpi.c
+++ b/board/raspberrypi/rpi/rpi.c
@@ -301,9 +301,6 @@ static void set_fdtfile(void)
  */
 static void set_fdt_addr(void)
 {
-	if (env_get("fdt_addr"))
-		return;
-
 	if (fdt_magic(fw_dtb_pointer) != FDT_MAGIC)
 		return;
 


### PR DESCRIPTION
After debugging (and adding some printouts) following was observed:
- when first time boot image board set fdt_addr variable (read during boot from rpi firmware) value is:
```
Setting fdt_addr to :0x1bfea000
```

after resize is done with raspi-config and board is restarted we see following debug:
```
fdt_addr:0x1bfea000 - fw_dtb_pointer:0x1bfea100
```
so firmware reported other value then first time (I think it's due to the fact that cmdline.txt was modified)

Then with fix with this PR is checked when stored value differ from actual one replace env variable with new value (maybe add check if magic is OK). With this fix issue https://tracker.mender.io/browse/MEN-2436 is fixed
