### PR TITLE
Disable addition of simple-framebuffer by U-boot.

### DIFF
--- a/board/raspberrypi/rpi/rpi.c
+++ b/board/raspberrypi/rpi/rpi.c
@@ -477,13 +477,6 @@ void *board_fdt_blob_setup(void)
 
 int ft_board_setup(void *blob, bd_t *bd)
 {
-	/*
-	 * For now, we simply always add the simplefb DT node. Later, we
-	 * should be more intelligent, and e.g. only do this if no enabled DT
-	 * node exists for the "real" graphics driver.
-	 */
-	lcd_dt_simplefb_add_node(blob);
-
 #ifdef CONFIG_EFI_LOADER
 	/* Reserve the spin table */
 	efi_add_memory_map(0, 1, EFI_RESERVED_MEMORY_TYPE, 0);

--- a/include/configs/rpi.h
+++ b/include/configs/rpi.h
@@ -60,9 +60,6 @@
 /* Devices */
 /* GPIO */
 #define CONFIG_BCM2835_GPIO
-/* LCD */
-#define CONFIG_LCD_DT_SIMPLEFB
-#define CONFIG_VIDEO_BCM2835
 
 #ifdef CONFIG_CMD_USB
 #define CONFIG_TFTP_TSIZE


### PR DESCRIPTION
In order to enable HDMI support for the Raspberry Pi, U-boot adds a
simple-framebuffer node to the device tree. However, this then prevents
the kernel from being able to correctly initialise the HDMI (which results
in a corrupted terminal), which subsequently prevents the camera from working.
Disabling HDMI support in U-boot resolves this issue. The U-boot console is
still available over the serial port.

This is a problem one of my clients has faced when trying to integrate Mender into their Raspberry Pi 3-based system. They are using the RPi camera and noticed that after running mender-convert on their golden image, the HDMI terminal is corrupted and, more importantly, the camera stops working. By disabling HDMI support in U-boot for the Raspberry Pi, this problem is resolved.

I don't imagine that loosing access to the U-boot terminal over HDMI is a big loss, since I would expect that most people using mender-convert to integrate Mender into their system would not need to configure U-boot, since mender-convert does it all for them. The U-boot terminal is still available over the serial port.